### PR TITLE
Fix in-tree optee_os build for Android 10

### DIFF
--- a/core/sub.mk
+++ b/core/sub.mk
@@ -7,7 +7,7 @@ ifeq ($(CFG_WITH_USER_TA),y)
 gensrcs-y += ta_pub_key
 produce-ta_pub_key = ta_pub_key.c
 depends-ta_pub_key = $(TA_SIGN_KEY) scripts/pem_to_pub_c.py
-recipe-ta_pub_key = scripts/pem_to_pub_c.py --prefix ta_pub_key \
+recipe-ta_pub_key = PATH=$(HOST_PYTHON):$(PATH) scripts/pem_to_pub_c.py --prefix ta_pub_key \
 		--key $(TA_SIGN_KEY) --out $(sub-dir-out)/ta_pub_key.c
 cleanfiles += $(sub-dir-out)/ta_pub_key.c
 endif

--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -43,7 +43,7 @@ libdirs 	:= $(out-dir)/$(base-prefix)$(libdir) $(libdirs)
 libnames	:= $(libname) $(libnames)
 libdeps		:= $(lib-libfile) $(libdeps)
 
-SIGN = scripts/sign.py
+SIGN = PATH=$(HOST_PYTHON):$(PATH) scripts/sign.py
 TA_SIGN_KEY ?= keys/default_ta.pem
 
 define process-lib

--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -2,7 +2,7 @@ link-script$(sm) = $(ta-dev-kit-dir$(sm))/src/ta.ld.S
 link-script-pp$(sm) = $(link-out-dir$(sm))/ta.lds
 link-script-dep$(sm) = $(link-out-dir$(sm))/.ta.ld.d
 
-SIGN ?= $(ta-dev-kit-dir$(sm))/scripts/sign.py
+SIGN ?= PATH=$(HOST_PYTHON):$(PATH) $(ta-dev-kit-dir$(sm))/scripts/sign.py
 TA_SIGN_KEY ?= $(ta-dev-kit-dir$(sm))/keys/default_ta.pem
 
 all: $(link-out-dir$(sm))/$(user-ta-uuid).dmp \

--- a/ta/arch/arm/link_shlib.mk
+++ b/ta/arch/arm/link_shlib.mk
@@ -3,7 +3,7 @@ $(error SHLIBUUID not set)
 endif
 link-out-dir = $(out-dir)
 
-SIGN ?= $(TA_DEV_KIT_DIR)/scripts/sign.py
+SIGN ?= PATH=$(HOST_PYTHON):$(PATH) $(TA_DEV_KIT_DIR)/scripts/sign.py
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 
 all: $(link-out-dir)/$(shlibname).so $(link-out-dir)/$(shlibname).dmp \


### PR DESCRIPTION
Add variable HOST_PYTHON for propagating a specific
python environment. This needed for an in-tree optee_os
build of the Android 10, which doesn't have python-crypto
support in prebuilt. Scripts with python-crypto dependancy:
scripts/pem_to_pub_c.py
scripts/sign.py

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
