### PR TITLE
Revert "link.mk: implement support for libnames-after-libgcc variable"

### DIFF
--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -49,11 +49,8 @@ cleanfiles += $(link-out-dir$(sm))/dyn_list
 
 link-ldadd  = $(user-ta-ldadd) $(addprefix -L,$(libdirs))
 link-ldadd += --start-group $(addprefix -l,$(libnames)) --end-group
+ldargs-$(user-ta-uuid).elf := $(link-ldflags) $(objs) $(link-ldadd)
 
-link-ldadd-after-libgcc += $(addprefix -l,$(libnames-after-libgcc))
-
-ldargs-$(user-ta-uuid).elf := $(link-ldflags) $(objs) $(link-ldadd) \
-				$(libgcc$(sm)) $(link-ldadd-after-libgcc)
 
 link-script-cppflags-$(sm) := \
 	$(filter-out $(CPPFLAGS_REMOVE) $(cppflags-remove), \
@@ -73,7 +70,6 @@ $(link-script-pp$(sm)): $(link-script$(sm)) $(conf-file) $(link-script-pp-makefi
 		$(link-script-cppflags-$(sm)) $$< -o $$@
 
 $(link-out-dir$(sm))/$(user-ta-uuid).elf: $(objs) $(libdeps) \
-					  $(libdeps-after-libgcc) \
 					  $(link-script-pp$(sm)) \
 					  $(dynlistdep) \
 					  $(additional-link-deps)


### PR DESCRIPTION
The mentioned commit was back-ported from newer version of OP-TEE, where
TAs to link with libgcc.a

But, it appears that in on this version, this change is not needed.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
